### PR TITLE
chore: run act via pre-commit hook

### DIFF
--- a/scripts/pre-commit-tests.sh
+++ b/scripts/pre-commit-tests.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-# Simple pre-commit hook that runs lake test
+set -euo pipefail
 
-set -e
+if ! command -v act >/dev/null 2>&1; then
+    echo "pre-commit hook error: act is not installed or not in PATH" >&2
+    exit 1
+fi
 
-echo "Running pre-commit hook: lake test"
-lake test
+echo "Running pre-commit hook: act pull_request (PR workflow)"
+act pull_request


### PR DESCRIPTION
## Summary
- run the pre-commit hook through act so local commits mirror CI
- bail out with a clear error when act is missing

## Testing
- ./scripts/pre-commit-tests.sh